### PR TITLE
Finished most of Collaborative Game Setup

### DIFF
--- a/backend/src/main/java/com/java/backend/CrossWorks/collaborative/CollaborativeGame.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/collaborative/CollaborativeGame.java
@@ -2,18 +2,52 @@ package com.java.backend.CrossWorks.collaborative;
 
 import java.util.UUID;
 import java.util.Vector;
+
+import com.java.backend.CrossWorks.exceptions.InvalidMove;
 import com.java.backend.CrossWorks.models.Crossword;
+import com.java.backend.CrossWorks.models.GameStatus;
 import com.java.backend.CrossWorks.models.Grid;
+import com.java.backend.CrossWorks.models.GridCell;
 
 public class CollaborativeGame {
     private String gameId;
     private Vector<CollaborativePlayer> players;
     private Crossword crossword;
     private Grid answers;
+    private GameStatus status;
 
-    public CollaborativeGame() {
-        gameId = UUID.randomUUID().toString();
+    private int numFilled;
+    private int numCorrect;
+    private int numCells;
+
+    public CollaborativeGame(String gameId) {
+        gameId = gameId;
         players = new Vector();
+        status = GameStatus.NOT_STARTED;
+    }
+
+    public void setCrossword(String crosswordId) {
+        Crossword crossword = new Crossword(crosswordId);
+        answers = new Grid(crossword.getSize());
+        answers.copyStructure(crossword.getBoard());
+
+        numCells = crossword.getNumNumBlock();
+        numFilled = 0;
+        numCorrect = 0;
+
+    }
+
+    public void startGame() {
+        status = GameStatus.IN_PROGRESS;
+    }
+
+    public void endGame() {
+        status = GameStatus.FINISHED;
+        System.out.println("Game is finished");
+    }
+
+    public Boolean checkFinished() {
+        return numCorrect == numCells;
     }
 
     public void addPlayer(CollaborativePlayer player) {
@@ -27,4 +61,35 @@ public class CollaborativeGame {
         }
         return player_ids;
     }
+
+    public void makeMove(CollaborativePlayer player, int x, int y, char val) throws InvalidMove {
+        // mapping char -> GridCell
+        GridCell gridCellVal = GridCell.EMPTY;
+        for (GridCell cell: GridCell.values()) {
+            if (cell.charValue == val) {
+                gridCellVal = cell;
+            }
+        }
+
+        GridCell currentValue = answers.getCell(x, y);
+        if (currentValue == GridCell.BLOCK) {
+            throw new InvalidMove("Tried filling a blocked cell");
+        }
+
+        if (currentValue != GridCell.EMPTY) {
+            numFilled += 1;
+        }
+
+        answers.setCell(x, y, gridCellVal);
+        if (crossword.checkCell(x, y, gridCellVal)) {
+            numCorrect += 1;
+
+            if (checkFinished()) {
+                endGame();
+            }
+        }
+
+
+    }
+
 }

--- a/backend/src/main/java/com/java/backend/CrossWorks/collaborative/CollaborativePlayer.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/collaborative/CollaborativePlayer.java
@@ -11,4 +11,5 @@ public class CollaborativePlayer {
     public String getPlayerId() {
         return playerId;
     }
+
 }

--- a/backend/src/main/java/com/java/backend/CrossWorks/controller/CollaborativeGameController.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/controller/CollaborativeGameController.java
@@ -1,0 +1,26 @@
+package com.java.backend.CrossWorks.controller;
+
+import com.java.backend.CrossWorks.collaborative.CollaborativeGame;
+import com.java.backend.CrossWorks.collaborative.CollaborativePlayer;
+import com.java.backend.CrossWorks.service.GameService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/collaborative-game")
+public class CollaborativeGameController {
+    private final GameService gameService;
+
+    public CollaborativeGameController() {
+        this.gameService = new GameService();
+    }
+
+    @PostMapping("/start")
+    public ResponseEntity<CollaborativeGame> start(@RequestBody CollaborativePlayer player) {
+        System.out.println("start game request: " + player.getPlayerId());
+        return ResponseEntity.ok(gameService.createGame(player));
+    }
+}

--- a/backend/src/main/java/com/java/backend/CrossWorks/exceptions/InvalidMove.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/exceptions/InvalidMove.java
@@ -1,0 +1,13 @@
+package com.java.backend.CrossWorks.exceptions;
+
+public class InvalidMove extends Exception{
+    private String message;
+
+    public InvalidMove(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/backend/src/main/java/com/java/backend/CrossWorks/models/Crossword.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/models/Crossword.java
@@ -1,5 +1,7 @@
 package com.java.backend.CrossWorks.models;
 
+import com.java.backend.CrossWorks.exceptions.InvalidMove;
+
 public class Crossword {
     private String crosswordId;
     private Grid answers;
@@ -9,5 +11,29 @@ public class Crossword {
         // somehow get the size of the crossword
         int n = 10;
         answers = new Grid(n);
+        answers.randomFill();
+        // TODO: Use JPA storage to map id -> answers
+        // TODO: Use JPA storage to get hints
+    }
+
+    public Boolean checkCell(int x, int y, GridCell pred) throws InvalidMove {
+        int size = answers.getSize();
+        if (0 > x || x >= size || 0 > y && y >= size) {
+            throw new InvalidMove("x and y values are out of bounds");
+        }
+
+        return pred == answers.getCell(x, y);
+    }
+
+    public int getNumNumBlock() {
+        return answers.getNumNonBlock();
+    }
+
+    public int getSize() {
+        return answers.getSize();
+    }
+
+    public Grid getBoard() {
+        return answers;
     }
 }

--- a/backend/src/main/java/com/java/backend/CrossWorks/models/GameStatus.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/models/GameStatus.java
@@ -1,0 +1,5 @@
+package com.java.backend.CrossWorks.models;
+
+public enum GameStatus {
+    NOT_STARTED, IN_PROGRESS, FINISHED;
+}

--- a/backend/src/main/java/com/java/backend/CrossWorks/models/Grid.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/models/Grid.java
@@ -27,8 +27,25 @@ public class Grid {
         return board[x][y];
     }
 
+    public void setCell(int x, int y, GridCell cell) {
+        board[x][y] = cell;
+    }
+
     public int getSize() {
         return size;
+    }
+
+    public int getNumNonBlock() {
+        int counter = 0;
+        for (int x = 0; x < size; x++) {
+            for (int y = 0; y < size; y++) {
+               if (board[x][y] != GridCell.BLOCK) {
+                  counter += 1;
+               }
+            }
+        }
+
+        return counter;
     }
 
     public void clearBoard() {

--- a/backend/src/main/java/com/java/backend/CrossWorks/service/GameService.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/service/GameService.java
@@ -2,10 +2,24 @@ package com.java.backend.CrossWorks.service;
 
 import com.java.backend.CrossWorks.collaborative.CollaborativeGame;
 import com.java.backend.CrossWorks.collaborative.CollaborativePlayer;
+import com.java.backend.CrossWorks.models.GridCell;
 
+import java.util.UUID;
+
+// GameService is the interface between JPA and the Games
 public class GameService {
     public CollaborativeGame createGame(CollaborativePlayer player){
-        CollaborativeGame game = new CollaborativeGame();
+        String gameId = UUID.randomUUID().toString();
+        CollaborativeGame game = new CollaborativeGame(gameId);
+
+        game.addPlayer(player);
+        // TODO: Store this game in JPA storage
+
         return game;
     }
+
+    // TODO: retrieve gameId from JPA storage
+    // public CollaborativeGame connectToGame(CollaborativePlayer player2, String gameId) {
+        // return the game retrieved from jpa storage
+    // }
 }

--- a/backend/src/test/java/com/java/backend/CrossWorks/collaborative/CollaborativeGameTests.java
+++ b/backend/src/test/java/com/java/backend/CrossWorks/collaborative/CollaborativeGameTests.java
@@ -9,7 +9,7 @@ class CollaborativeGameTests {
 
     @Test
     void correctPlayerIds() {
-        CollaborativeGame game = new CollaborativeGame();
+        CollaborativeGame game = new CollaborativeGame("fill in later");
         CollaborativePlayer playerOne = new CollaborativePlayer();
         CollaborativePlayer playerTwo = new CollaborativePlayer();
 


### PR DESCRIPTION
## Changes
- fleshed out `CollaborativeGame`, `CollaborativePlayer`, `CrossWord`, `Grid`
- Made a `CollaborativeGameController` that connects the frontend to the game logic using API endpoints
- `GameService` is mostly still boilerplate since JPA data storage has not been implemented yet

## Tech Debt
- `CollaborativeGameController` is still largely unfinished because need to setup web socket communication first, so gonna wait for @mamugu01 to finish his ticket
- `GameService` is mostly unfinished since JPA storage is part of the next ticket. So, if games are created, they are not stored anywhere.
- `Crossword` takes in a `crosswordId` as a parameter, but has right now doesn't use it and just randomly generates a crossword - need to somehow connect this with our "crossword database"

## Issues fixed (add the issue number after #)
fixes #9 

## Screenshots (drag and drop images to include them)
