### PR TITLE
setting up crossword and game JPA

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/backend/src/main/java/com/java/backend/CrossWorks/CrossWorksApplication.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/CrossWorksApplication.java
@@ -1,13 +1,46 @@
 package com.java.backend.CrossWorks;
 
+import com.java.backend.CrossWorks.collaborative.CollaborativeGame;
+import com.java.backend.CrossWorks.models.Crossword;
+import com.java.backend.CrossWorks.storage.CollaborativeGameStorage;
+import com.java.backend.CrossWorks.storage.CrosswordStorage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class CrossWorksApplication {
 
+	private static final Logger log = LoggerFactory.getLogger(CrossWorksApplication.class);
 	public static void main(String[] args) {
 		SpringApplication.run(CrossWorksApplication.class, args);
+	}
+
+	@Bean
+	public CommandLineRunner crosswordInitialization(CrosswordStorage repository) {
+		return (args) -> {
+			repository.save(new Crossword("hello", 10));
+			log.info("Crossword files found with findAll()");
+			for (Crossword file: repository.findAll()) {
+				log.info("Crossword");
+				log.info(file.getCrosswordId());
+			}
+		};
+	}
+	@Bean
+	public CommandLineRunner demo(CollaborativeGameStorage repository) {
+		return (args) -> {
+			repository.save(new CollaborativeGame("gameOne"));
+			repository.save(new CollaborativeGame("gameTwo"));
+			log.info("games found with findAll():");
+			for (CollaborativeGame game: repository.findAll()) {
+				log.info("Game");
+				log.info(game.getGameId());
+			}
+		};
 	}
 
 }

--- a/backend/src/main/java/com/java/backend/CrossWorks/collaborative/CollaborativeGame.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/collaborative/CollaborativeGame.java
@@ -9,10 +9,19 @@ import com.java.backend.CrossWorks.models.GameStatus;
 import com.java.backend.CrossWorks.models.Grid;
 import com.java.backend.CrossWorks.models.GridCell;
 
+import javax.persistence.*;
+
+@Entity
 public class CollaborativeGame {
+    @Id
+    @GeneratedValue(strategy=GenerationType.AUTO)
+    private Long id;
+
     private String gameId;
     private Vector<CollaborativePlayer> players;
+    @ManyToOne(cascade = {CascadeType.ALL})
     private Crossword crossword;
+    @ManyToOne(cascade = {CascadeType.ALL})
     private Grid answers;
     private GameStatus status;
 
@@ -20,14 +29,25 @@ public class CollaborativeGame {
     private int numCorrect;
     private int numCells;
 
+    protected CollaborativeGame() {}
+
     public CollaborativeGame(String gameId) {
-        gameId = gameId;
+        this.gameId = gameId;
         players = new Vector();
         status = GameStatus.NOT_STARTED;
+        setCrossword("todo later");
+    }
+
+    public String getGameId() {
+        return gameId;
+    }
+
+    public Long getId() {
+        return id;
     }
 
     public void setCrossword(String crosswordId) {
-        Crossword crossword = new Crossword(crosswordId);
+        Crossword crossword = new Crossword(crosswordId, 10);
         answers = new Grid(crossword.getSize());
         answers.copyStructure(crossword.getBoard());
 

--- a/backend/src/main/java/com/java/backend/CrossWorks/models/Crossword.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/models/Crossword.java
@@ -2,18 +2,31 @@ package com.java.backend.CrossWorks.models;
 
 import com.java.backend.CrossWorks.exceptions.InvalidMove;
 
+import javax.persistence.*;
+import java.util.UUID;
+
+@Entity
 public class Crossword {
+    @Id
     private String crosswordId;
+    @ManyToOne(cascade = {CascadeType.ALL})
     private Grid answers;
 
-    public Crossword(String id) {
-        crosswordId = id;
+    protected Crossword() {
+        this(UUID.randomUUID().toString(), 10);
+    }
+
+    public Crossword(String crosswordId, int size) {
+        this.crosswordId = crosswordId;
         // somehow get the size of the crossword
-        int n = 10;
-        answers = new Grid(n);
+        answers = new Grid(size);
         answers.randomFill();
         // TODO: Use JPA storage to map id -> answers
         // TODO: Use JPA storage to get hints
+    }
+
+    public String getCrosswordId() {
+        return crosswordId;
     }
 
     public Boolean checkCell(int x, int y, GridCell pred) throws InvalidMove {

--- a/backend/src/main/java/com/java/backend/CrossWorks/models/Grid.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/models/Grid.java
@@ -1,15 +1,30 @@
 package com.java.backend.CrossWorks.models;
 
+import javax.persistence.*;
 import java.util.Random;
 
+@Entity
 public class Grid {
+    @Id
+    @GeneratedValue(strategy= GenerationType.AUTO)
+    private Long id;
+
+    @Column(columnDefinition="LONGTEXT")
     private final GridCell[][] board;
     private final int size;
+
+    protected Grid() {
+        this(10);
+    }
 
     public Grid(int s) {
         size = s;
         board = new GridCell[size][size];
         clearBoard();
+    }
+
+    public Long getId() {
+        return id;
     }
 
     // deep copy constructor

--- a/backend/src/main/java/com/java/backend/CrossWorks/storage/CollaborativeGameStorage.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/storage/CollaborativeGameStorage.java
@@ -1,0 +1,11 @@
+package com.java.backend.CrossWorks.storage;
+
+import java.util.List;
+
+import com.java.backend.CrossWorks.collaborative.CollaborativeGame;
+import org.springframework.data.repository.CrudRepository;
+
+public interface CollaborativeGameStorage extends CrudRepository<CollaborativeGame, Long> {
+
+    CollaborativeGame findById(long id);
+}

--- a/backend/src/main/java/com/java/backend/CrossWorks/storage/CrosswordStorage.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/storage/CrosswordStorage.java
@@ -1,0 +1,9 @@
+package com.java.backend.CrossWorks.storage;
+
+import com.java.backend.CrossWorks.models.Crossword;
+import org.springframework.data.repository.CrudRepository;
+
+public interface CrosswordStorage extends CrudRepository<Crossword, String> {
+
+    Crossword findByCrosswordId(String crosswordId);
+}

--- a/backend/src/main/resources/sampleCrossword.json
+++ b/backend/src/main/resources/sampleCrossword.json
@@ -1,0 +1,120 @@
+{
+  "crosswordId": "sampleCrossword",
+  "date": "October 2, 2021",
+  "source": "NYT-mini",
+  "size": 7
+  "clues": [
+    {
+      "hintNumber": 1,
+      "hint": "Australian greeting",
+      "x": 0,
+      "y": 0,
+      "answer": "GDAY",
+      "direction": "ACROSS"
+    },
+    {
+      "hintNumber": 5,
+      "hint": "Turn back to zero",
+      "x": 1,
+      "y": 0,
+      "answer": "RESET",
+      "direction": "ACROSS"
+    },
+    {
+      "hintNumber": 7,
+      "hint": "Key that's equivalent to B♭",
+      "x": 2,
+      "y": 0,
+      "answer": "ASHARP",
+      "direction": "ACROSS"
+    },
+    {
+      "hintNumber": 9,
+      "hint": "Wedded",
+      "x": 3,
+      "y": 0,
+      "answer": "MARRIED",
+      "direction": "ACROSS"
+    },
+    {
+      "hintNumber": 11,
+      "hint": "Country with a maple leaf on its flag",
+      "x": 4,
+      "y": 1,
+      "answer": "CANADA",
+      "direction": "ACROSS"
+    },
+    {
+      "hintNumber": 12,
+      "hint": "Rap's ___ Thee Stallion",
+      "x": 5,
+      "y": 2,
+      "answer": "MEGAN",
+      "direction": "ACROSS"
+    },
+    {
+      "hintNumber": 13,
+      "hint": "Sandwich shop",
+      "x": 6,
+      "y": 3,
+      "answer": "DELI",
+      "direction": "ACROSS"
+    },
+    {
+      "hintNumber": 1,
+      "hint": "\"g,\" to a chemist",
+      "x": 0,
+      "y": 0,
+      "answer": "GRAM",
+      "direction": "DOWN"
+    },
+    {
+      "hintNumber": 2,
+      "hint": "Cul-___ (kind of street)",
+      "x": 0,
+      "y": 1,
+      "answer": "DESAC",
+      "direction": "DOWN"
+    },
+    {
+      "hintNumber": 3,
+      "hint": "Guru's residence",
+      "x": 0,
+      "y": 2,
+      "answer": "ASHRAM",
+      "direction": "DOWN"
+    },
+    {
+      "hintNumber": 4,
+      "hint": "Had a deep desire",
+      "x": 0,
+      "y": 3,
+      "answer": "YEARNED",
+      "direction": "DOWN"
+    },
+    {
+      "hintNumber": 6,
+      "hint": "Emergency sorting process",
+      "x": 1,
+      "y": 4,
+      "answer": "TRIAGE",
+      "direction": "DOWN"
+    },
+    {
+      "hintNumber": 8,
+      "hint": "Ride a bike",
+      "x": 2,
+      "y": 5,
+      "answer": "PEDAL",
+      "direction": "DOWN"
+    },
+    {
+      "hintNumber": 10,
+      "hint": "\"___ California\" (Red Hot Chili Peppers hit)",
+      "x": 3,
+      "y": 6,
+      "answer": "DANI",
+      "direction": "DOWN"
+    }
+  ]
+}


### PR DESCRIPTION
## Changes
- Prepared Crossword, Grid, and Games as entities with unique IDs that can go inside of a JPA database
- Created two JPA repositories (CrosswordStorage, CompetitiveGame storage) that are essentially hash tables using the unique IDs from above
- Added tests in the CrossWorksApplication.java
- Added json-simple dependency (for later PR)
- Added a test json file of a sample crossword.

## Issues fixed (add the issue number after #)
fixes #18 

## Screenshots (drag and drop images to include them)
