### PR TITLE
Loading crossword data and creating sample endpoint

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'org.springframework.boot' version '2.5.5'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
+	id "io.freefair.lombok" version "6.2.0"
 }
 
 group = 'com.java.backend'
@@ -17,6 +18,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'com.googlecode.json-simple:json-simple:1.1.1'
+    implementation 'org.projectlombok:lombok:1.18.20'
+	implementation 'org.projectlombok:lombok:1.18.20'
+	implementation 'org.projectlombok:lombok:1.18.20'
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/backend/src/main/java/com/java/backend/CrossWorks/CrossWorksApplication.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/CrossWorksApplication.java
@@ -1,5 +1,7 @@
 package com.java.backend.CrossWorks;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.java.backend.CrossWorks.collaborative.CollaborativeGame;
 import com.java.backend.CrossWorks.models.Crossword;
 import com.java.backend.CrossWorks.storage.CollaborativeGameStorage;
@@ -10,6 +12,9 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 @SpringBootApplication
 public class CrossWorksApplication {
@@ -22,10 +27,22 @@ public class CrossWorksApplication {
 	@Bean
 	public CommandLineRunner crosswordInitialization(CrosswordStorage repository) {
 		return (args) -> {
-			repository.save(new Crossword("hello", 10));
+			ObjectMapper mapper = new ObjectMapper();
+			TypeReference<Crossword> typeReference = new TypeReference<Crossword>(){};
+			InputStream inputStream = TypeReference.class.getResourceAsStream("/sampleCrossword.json");
+			try {
+				Crossword data = mapper.readValue(inputStream,typeReference);
+				data.fillAnswers();
+				data.getBoard().printBoard();
+				repository.save(data);
+				log.info("crossword data saved");
+			} catch (IOException e){
+				log.info("didn't work");
+				log.info(e.toString());
+			}
+
 			log.info("Crossword files found with findAll()");
 			for (Crossword file: repository.findAll()) {
-				log.info("Crossword");
 				log.info(file.getCrosswordId());
 			}
 		};
@@ -33,11 +50,10 @@ public class CrossWorksApplication {
 	@Bean
 	public CommandLineRunner demo(CollaborativeGameStorage repository) {
 		return (args) -> {
-			repository.save(new CollaborativeGame("gameOne"));
-			repository.save(new CollaborativeGame("gameTwo"));
+			repository.save(new CollaborativeGame());
+			repository.save(new CollaborativeGame());
 			log.info("games found with findAll():");
 			for (CollaborativeGame game: repository.findAll()) {
-				log.info("Game");
 				log.info(game.getGameId());
 			}
 		};

--- a/backend/src/main/java/com/java/backend/CrossWorks/collaborative/Game.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/collaborative/Game.java
@@ -1,0 +1,47 @@
+package com.java.backend.CrossWorks.collaborative;
+
+import com.java.backend.CrossWorks.models.Crossword;
+import com.java.backend.CrossWorks.models.Datatype;
+import com.java.backend.CrossWorks.models.GameStatus;
+import com.java.backend.CrossWorks.models.GridCell;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@MappedSuperclass
+public class Game {
+    @Id
+    private String gameId;
+    @ManyToOne(cascade = {CascadeType.ALL})
+    private Crossword crossword;
+    private GameStatus status;
+
+    public Game() {
+        this(Datatype.GAME.prefix + UUID.randomUUID().toString());
+    }
+
+    public Game(String gameId) {
+        this.gameId = gameId;
+        status = GameStatus.NOT_STARTED;
+    }
+
+    public void changeCrossword(Crossword crossword) {
+        this.crossword = crossword;
+    }
+
+    public String getGameId() {
+        return gameId;
+    }
+
+    public void startGame() {
+        status = GameStatus.IN_PROGRESS;
+    }
+
+    public void endGame() {
+        status = GameStatus.FINISHED;
+    }
+
+    public GridCell getCell(int x, int y) {
+        return crossword.getAnswers().getCell(x, y);
+    }
+}

--- a/backend/src/main/java/com/java/backend/CrossWorks/collaborative/Player.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/collaborative/Player.java
@@ -1,12 +1,14 @@
 package com.java.backend.CrossWorks.collaborative;
 
+import com.java.backend.CrossWorks.models.Datatype;
+
 import java.util.UUID;
 
-public class CollaborativePlayer {
+public class Player{
     private final String playerId;
 
-    public CollaborativePlayer() {
-        playerId = UUID.randomUUID().toString();
+    public Player() {
+        playerId = Datatype.COLLABORATIVE_PLAYER.prefix + UUID.randomUUID().toString();
     }
     public String getPlayerId() {
         return playerId;

--- a/backend/src/main/java/com/java/backend/CrossWorks/collaborative/TeamAnswers.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/collaborative/TeamAnswers.java
@@ -1,0 +1,73 @@
+package com.java.backend.CrossWorks.collaborative;
+
+import com.java.backend.CrossWorks.exceptions.InvalidMove;
+import com.java.backend.CrossWorks.models.Datatype;
+import com.java.backend.CrossWorks.models.Grid;
+import com.java.backend.CrossWorks.models.GridCell;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Entity
+public class TeamAnswers {
+    @Id
+    private String teamAnswersId;
+
+    @ManyToOne(cascade = {CascadeType.ALL})
+    private Grid answers;
+    private int numFilled;
+    private int numCorrect;
+    private int numCells;
+
+    public TeamAnswers(Grid answers, int numCells) {
+        this.teamAnswersId = Datatype.TEAM_ANSWERS.prefix + UUID.randomUUID().toString();
+        this.answers = answers;
+        numFilled = 0;
+        numCorrect = 0;
+        this.numCells = numCells;
+    }
+
+    public void makeMove(int x, int y, GridCell newValue, GridCell correctValue) throws InvalidMove {
+        GridCell oldValue = answers.getCell(x, y);
+
+        if (newValue == GridCell.BLOCK) {
+            throw new InvalidMove("Tried fillling a blocked cell");
+        }
+
+        if(newValue == oldValue) {
+            return;
+        }
+
+        boolean newCorrect = newValue == correctValue;
+        boolean oldCorrect = oldValue == correctValue;
+
+        if (!oldValue.isEmpty() && !newValue.isEmpty()) {
+            // both are nonempty
+            if (oldCorrect) {
+                numCorrect -= 1;
+            }
+            if (newCorrect) {
+                numCorrect += 1;
+            }
+        } else if (!oldValue.isEmpty() && newValue.isEmpty()) {
+            // was nonempty, not it is empty
+            numFilled -= 1;
+            if (oldCorrect) {
+                numCorrect -= 1;
+            }
+        } else if (oldValue.isEmpty() && !newValue.isEmpty()) {
+            // was empty, now it is nonempty
+            numFilled += 1;
+            if (newCorrect) {
+                numCorrect += 1;
+            }
+        }
+
+        answers.setCell(x, y, newValue);
+    }
+
+    public boolean checkFinished() {
+        return numCorrect == numCells;
+    }
+
+}

--- a/backend/src/main/java/com/java/backend/CrossWorks/controller/CollaborativeGameController.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/controller/CollaborativeGameController.java
@@ -1,26 +1,39 @@
 package com.java.backend.CrossWorks.controller;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.java.backend.CrossWorks.collaborative.CollaborativeGame;
-import com.java.backend.CrossWorks.collaborative.CollaborativePlayer;
+import com.java.backend.CrossWorks.collaborative.Player;
+import com.java.backend.CrossWorks.models.Crossword;
+import com.java.backend.CrossWorks.service.CrosswordService;
 import com.java.backend.CrossWorks.service.GameService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.lang.reflect.Method;
 
 @RestController
 @RequestMapping("/collaborative-game")
 public class CollaborativeGameController {
     private final GameService gameService;
+    @Autowired
+    private CrosswordService crosswordService;
 
     public CollaborativeGameController() {
         this.gameService = new GameService();
     }
 
+    @GetMapping("/sample-crossword")
+    @ResponseBody
+    @JsonIgnoreProperties("answers")
+    public Crossword sampleCrossword() {
+        return crosswordService.getFirst();
+    }
+
     @PostMapping("/start")
-    public ResponseEntity<CollaborativeGame> start(@RequestBody CollaborativePlayer player) {
-        System.out.println("start game request: " + player.getPlayerId());
+    public ResponseEntity<CollaborativeGame> start(@RequestBody Player player) {
         return ResponseEntity.ok(gameService.createGame(player));
     }
 }

--- a/backend/src/main/java/com/java/backend/CrossWorks/models/Crossword.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/models/Crossword.java
@@ -1,28 +1,71 @@
 package com.java.backend.CrossWorks.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.java.backend.CrossWorks.exceptions.InvalidMove;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
 import javax.persistence.*;
+import java.util.List;
 import java.util.UUID;
+import java.util.Vector;
 
+@Data
+@AllArgsConstructor
+@Embeddable
 @Entity
 public class Crossword {
     @Id
     private String crosswordId;
+
+    private String name;
+    private String date;
+    private String source;
+    private int size;
+    @Column( length = 10000)
+    private Vector<CrosswordHint> clues;
     @ManyToOne(cascade = {CascadeType.ALL})
+
+    @JsonIgnore
     private Grid answers;
 
     protected Crossword() {
-        this(UUID.randomUUID().toString(), 10);
+        this.crosswordId = Datatype.CROSSWORD.prefix + UUID.randomUUID().toString();
     }
 
-    public Crossword(String crosswordId, int size) {
-        this.crosswordId = crosswordId;
-        // somehow get the size of the crossword
+    // should only fill after all the hints have been added;
+    public void fillAnswers() {
         answers = new Grid(size);
-        answers.randomFill();
-        // TODO: Use JPA storage to map id -> answers
-        // TODO: Use JPA storage to get hints
+        boolean valid = true;
+        for(CrosswordHint hint: clues) {
+           valid = processHint(hint) && valid;
+        }
+
+        if (!valid) {
+           answers.clear();
+        }
+
+        // if the clues aren't valid, then we just make the entire board black
+        answers.blacken();
+    }
+
+    public Boolean processHint(CrosswordHint hint) {
+        String answer = hint.getAnswer();
+        int isAcross = hint.direction == Direction.ACROSS ? 1 : 0;
+        for(int i = hint.x; i < answer.length(); i++) {
+            int x = hint.x + (1 - isAcross) * i;
+            int y = hint.y + isAcross * i;
+            GridCell currCell = answers.getCell(x, y);
+            GridCell newCell = GridCell.charValueOf(answer.charAt(i));
+
+            if (currCell == GridCell.EMPTY) {
+                answers.setCell(x, y, newCell);
+            } else if (newCell != currCell) {
+                // TODO: figure out better error handeling here
+                return false;
+            }
+        }
+        return true;
     }
 
     public String getCrosswordId() {
@@ -38,15 +81,25 @@ public class Crossword {
         return pred == answers.getCell(x, y);
     }
 
-    public int getNumNumBlock() {
-        return answers.getNumNonBlock();
-    }
-
     public int getSize() {
         return answers.getSize();
     }
 
+    public String getSource() {
+        return source;
+    }
+
+    public CrosswordHint getHint(int x) {
+        return clues.get(x);
+    }
+
+    @JsonIgnore
     public Grid getBoard() {
         return answers;
+    }
+
+    @JsonIgnore
+    public int getNumNonBlock() {
+        return answers.getNumNonBlock();
     }
 }

--- a/backend/src/main/java/com/java/backend/CrossWorks/models/CrosswordHint.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/models/CrosswordHint.java
@@ -1,0 +1,37 @@
+package com.java.backend.CrossWorks.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+@Embeddable
+@Entity
+public class CrosswordHint implements Serializable {
+    @Id
+    private String crosswordHintId;
+
+    public int hintNumber;
+    public String hint;
+    public int x;
+    public int y;
+    private String answer;
+    public Direction direction;
+
+    public CrosswordHint () {
+        this.crosswordHintId = Datatype.CROSSWORD_HINT + UUID.randomUUID().toString();
+    }
+
+    public String getAnswer(){
+        return answer;
+    }
+
+    @Override
+    public String toString() {
+       return hint + " " + String.valueOf(x) + " " + String.valueOf(y) + " " + answer;
+    }
+}

--- a/backend/src/main/java/com/java/backend/CrossWorks/models/Datatype.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/models/Datatype.java
@@ -1,0 +1,19 @@
+package com.java.backend.CrossWorks.models;
+
+public enum Datatype {
+    CROSSWORD("crossword-"),
+    CROSSWORD_HINT("crossword_hint-"),
+    TEAM_ANSWERS("team-answers-"),
+    COLLABORATIVE_PLAYER("collaborative_player-"),
+    GAME("game-"),
+    COLLABORATIVE_GAME("collaborative_game-"),
+    COMPETITIVE_GAME("competitive_game-");
+
+    public final String prefix;
+
+    Datatype(String prefix) {
+        this.prefix = prefix;
+    }
+
+
+}

--- a/backend/src/main/java/com/java/backend/CrossWorks/models/Direction.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/models/Direction.java
@@ -1,0 +1,5 @@
+package com.java.backend.CrossWorks.models;
+
+public enum Direction {
+    ACROSS, DOWN
+}

--- a/backend/src/main/java/com/java/backend/CrossWorks/models/Grid.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/models/Grid.java
@@ -20,7 +20,7 @@ public class Grid {
     public Grid(int s) {
         size = s;
         board = new GridCell[size][size];
-        clearBoard();
+        clear();
     }
 
     public Long getId() {
@@ -63,10 +63,20 @@ public class Grid {
         return counter;
     }
 
-    public void clearBoard() {
+    public void clear() {
         for (int x = 0; x < size; x++) {
             for (int y = 0; y < size; y++) {
                 board[x][y] = GridCell.EMPTY;
+            }
+        }
+    }
+
+    public void blacken() {
+        for (int x = 0; x < size; x++) {
+            for (int y = 0; y < size; y++) {
+                if(board[x][y] == GridCell.EMPTY) {
+                    board[x][y] = GridCell.BLOCK;
+                }
             }
         }
     }

--- a/backend/src/main/java/com/java/backend/CrossWorks/models/GridCell.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/models/GridCell.java
@@ -1,5 +1,8 @@
 package com.java.backend.CrossWorks.models;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public enum GridCell {
     BLOCK('#'),
     EMPTY(' '),
@@ -34,6 +37,23 @@ public enum GridCell {
 
     GridCell(char charValue) {
         this.charValue = charValue;
+    }
+
+    private static final Map<Character, GridCell> BY_CHAR_VALUE = new HashMap<>();
+
+    static {
+        for (GridCell cell: values()) {
+            BY_CHAR_VALUE.put(cell.charValue, cell);
+        }
+    }
+
+    public static GridCell charValueOf(char charValue) {
+        // TODO: if char value is not in the map, catch the error
+        return BY_CHAR_VALUE.get(charValue);
+    }
+
+    public boolean isEmpty() {
+        return this == GridCell.EMPTY;
     }
 }
 

--- a/backend/src/main/java/com/java/backend/CrossWorks/service/CrosswordService.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/service/CrosswordService.java
@@ -1,0 +1,28 @@
+package com.java.backend.CrossWorks.service;
+
+import com.java.backend.CrossWorks.models.Crossword;
+import com.java.backend.CrossWorks.storage.CrosswordStorage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Configurable;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@Configurable
+public class CrosswordService {
+    @Autowired
+    private CrosswordStorage repo;
+
+    public Crossword getCrossword(String crosswordId) {
+        return (Crossword) repo.findAllById(Collections.singleton(crosswordId));
+    }
+
+    public Crossword getFirst() {
+        Iterable<Crossword> allOfThem = repo.findAll();
+        return allOfThem.iterator().next();
+    }
+
+
+}

--- a/backend/src/main/java/com/java/backend/CrossWorks/service/GameService.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/service/GameService.java
@@ -1,16 +1,15 @@
 package com.java.backend.CrossWorks.service;
 
 import com.java.backend.CrossWorks.collaborative.CollaborativeGame;
-import com.java.backend.CrossWorks.collaborative.CollaborativePlayer;
+import com.java.backend.CrossWorks.collaborative.Player;
 import com.java.backend.CrossWorks.models.GridCell;
 
 import java.util.UUID;
 
 // GameService is the interface between JPA and the Games
 public class GameService {
-    public CollaborativeGame createGame(CollaborativePlayer player){
-        String gameId = UUID.randomUUID().toString();
-        CollaborativeGame game = new CollaborativeGame(gameId);
+    public CollaborativeGame createGame(Player player){
+        CollaborativeGame game = new CollaborativeGame();
 
         game.addPlayer(player);
         // TODO: Store this game in JPA storage

--- a/backend/src/main/java/com/java/backend/CrossWorks/storage/CollaborativeGameStorage.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/storage/CollaborativeGameStorage.java
@@ -1,11 +1,12 @@
 package com.java.backend.CrossWorks.storage;
 
-import java.util.List;
 
 import com.java.backend.CrossWorks.collaborative.CollaborativeGame;
 import org.springframework.data.repository.CrudRepository;
 
-public interface CollaborativeGameStorage extends CrudRepository<CollaborativeGame, Long> {
+import java.util.Optional;
 
-    CollaborativeGame findById(long id);
+public interface CollaborativeGameStorage extends CrudRepository<CollaborativeGame, String> {
+
+    Optional<CollaborativeGame> findById(String id);
 }

--- a/backend/src/main/resources/sampleCrossword.json
+++ b/backend/src/main/resources/sampleCrossword.json
@@ -1,8 +1,8 @@
 {
-  "crosswordId": "sampleCrossword",
+  "name": "sampleCrossword",
   "date": "October 2, 2021",
   "source": "NYT-mini",
-  "size": 7
+  "size": 7,
   "clues": [
     {
       "hintNumber": 1,

--- a/backend/src/test/java/com/java/backend/CrossWorks/collaborative/CollaborativeGameTests.java
+++ b/backend/src/test/java/com/java/backend/CrossWorks/collaborative/CollaborativeGameTests.java
@@ -9,9 +9,9 @@ class CollaborativeGameTests {
 
     @Test
     void correctPlayerIds() {
-        CollaborativeGame game = new CollaborativeGame("fill in later");
-        CollaborativePlayer playerOne = new CollaborativePlayer();
-        CollaborativePlayer playerTwo = new CollaborativePlayer();
+        CollaborativeGame game = new CollaborativeGame();
+        Player playerOne = new Player();
+        Player playerTwo = new Player();
 
         game.addPlayer(playerOne);
         game.addPlayer(playerTwo);


### PR DESCRIPTION
## Changes
- Read in `sampleCrossword.json` and store it in the CrosswordStorage JPA repository
- Worked on the abstraction for a game. A Game is a super class that has a gameId and the crossword data. The `CollaborativeGame` is a subclass of `Game` that keeps track of the players in a vector and uses a `TeamAnswers` object to store the team's answers.
- Created a `CrosswordService` that allows you to query the repository.
- Created a `CrosswordHint` class that stores information about a crossword's hint as well as answers.
- Created an endpoint at http://localhost:8080/collaborative-game/sample-crossword where you can retrieve data for a sample crossword.

## Issues fixed (add the issue number after #)
fixes #17 

## Screenshots (drag and drop images to include them)
