### PR TITLE
Information hiding for sample endpoint

### DIFF
--- a/backend/src/main/java/com/java/backend/CrossWorks/controller/CollaborativeGameController.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/controller/CollaborativeGameController.java
@@ -7,7 +7,7 @@ import com.java.backend.CrossWorks.collaborative.CollaborativeGame;
 import com.java.backend.CrossWorks.collaborative.Player;
 import com.java.backend.CrossWorks.models.Crossword;
 import com.java.backend.CrossWorks.service.CrosswordService;
-import com.java.backend.CrossWorks.service.GameService;
+import com.java.backend.CrossWorks.service.CollaborativeGameService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,12 +17,12 @@ import java.lang.reflect.Method;
 @RestController
 @RequestMapping("/collaborative-game")
 public class CollaborativeGameController {
-    private final GameService gameService;
+    @Autowired
+    private CollaborativeGameService gameService;
     @Autowired
     private CrosswordService crosswordService;
 
     public CollaborativeGameController() {
-        this.gameService = new GameService();
     }
 
     @GetMapping("/sample-crossword")

--- a/backend/src/main/java/com/java/backend/CrossWorks/models/CrosswordHint.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/models/CrosswordHint.java
@@ -1,5 +1,6 @@
 package com.java.backend.CrossWorks.models;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -19,6 +20,7 @@ public class CrosswordHint implements Serializable {
     public String hint;
     public int x;
     public int y;
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private String answer;
     public Direction direction;
 
@@ -34,4 +36,9 @@ public class CrosswordHint implements Serializable {
     public String toString() {
        return hint + " " + String.valueOf(x) + " " + String.valueOf(y) + " " + answer;
     }
+
+    public int getAnswerLength() {
+        return answer.length();
+    }
+
 }

--- a/backend/src/main/java/com/java/backend/CrossWorks/service/CollaborativeGameService.java
+++ b/backend/src/main/java/com/java/backend/CrossWorks/service/CollaborativeGameService.java
@@ -3,17 +3,26 @@ package com.java.backend.CrossWorks.service;
 import com.java.backend.CrossWorks.collaborative.CollaborativeGame;
 import com.java.backend.CrossWorks.collaborative.Player;
 import com.java.backend.CrossWorks.models.GridCell;
+import com.java.backend.CrossWorks.storage.CollaborativeGameStorage;
+import com.java.backend.CrossWorks.storage.CrosswordStorage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Configurable;
+import org.springframework.stereotype.Service;
 
 import java.util.UUID;
 
 // GameService is the interface between JPA and the Games
-public class GameService {
+@Service
+@Configurable
+public class CollaborativeGameService {
+    @Autowired
+    private CollaborativeGameStorage repo;
+
     public CollaborativeGame createGame(Player player){
         CollaborativeGame game = new CollaborativeGame();
-
         game.addPlayer(player);
-        // TODO: Store this game in JPA storage
 
+        repo.save(game);
         return game;
     }
 

--- a/backend/src/test/java/com/java/backend/CrossWorks/service/GameServiceTests.java
+++ b/backend/src/test/java/com/java/backend/CrossWorks/service/GameServiceTests.java
@@ -9,7 +9,7 @@ class GameServiceTests {
 
     @Test
     void crosswordIsNotNull() {
-        GameService gameservice = new GameService();
+        CollaborativeGameService gameservice = new CollaborativeGameService();
 
         assertThat(gameservice).isNotNull();
     }


### PR DESCRIPTION
## Changes
- only answer length is shown at sample endpoint now, http://localhost:8080/collaborative-game/sample-crossword, rather than the actual answers
- some other small nits
-

## Issues fixed (add the issue number after #)
fixes #

## Screenshots (drag and drop images to include them)
